### PR TITLE
Update GoodNES.xmdb with Ultima typo fix

### DIFF
--- a/xmdb/GoodNES.xmdb
+++ b/xmdb/GoodNES.xmdb
@@ -550,7 +550,7 @@ Email: goodmerge@gmail.com
 <zoned><bias zone="U" name="Twin Eagle"/><bias zone="J" name="Twin Eagle - Revenge Joe's Brother"/></zoned>
 <zoned><bias zone="E" name="U-four-ia - The Saga"/><bias zone="J" name="Hebereke"/></zoned>
 <zoned><bias zone="U" name="Ultima - Exodus"/><bias zone="J" name="Ultima - Kyoufu no Exodus"/><clone name="Ultima - Exodus - Graphics Improve V3 by Zero Soul"/></zoned>
-<zoned><bias zone="U" name="Ultima - Quest of the Avatar"/><bias zone="J" name="Ultima - Seisha heno Michi"/></zoned>
+<zoned><bias zone="U" name="Ultima - Quest of the Avatar"/><bias zone="J" name="Ultima - Seisha e no Michi"/></zoned>
 <zoned><bias zone="En" name="Ultimate Air Combat"/><bias zone="J" name="Aces - Iron Eagle 3"/></zoned>
 <zoned><bias zone="U" name="Ultimate Basketball"/><bias zone="J" name="Taito Basketball"/><clone name="Toita Basketball"/></zoned>
 <zoned><bias zone="En" name="Ultimate League Soccer"/><bias zone="J" name="AV Soccer"/><clone name="Ultimate League Soccer (PAL)"/><clone name="Futebol"/></zoned>


### PR DESCRIPTION
The name of the Japense translation included "heno" instead of "e no".